### PR TITLE
pre-release-v6.0.1.4.5

### DIFF
--- a/bitapp/build.gradle.kts
+++ b/bitapp/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         applicationId = "com.atech.bit"
         minSdk = 24
         targetSdk = 34
-        versionCode = 80
-        versionName = "6.0.1.4.4"
+        versionCode = 81
+        versionName = "6.0.1.4.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ roomCompiler = "2.6.1"
 roomKtx = "2.6.1"
 roomPaging = "2.6.1"
 roomRuntime = "2.6.1"
-navigationCompose = "2.7.7"
+navigationCompose = "2.8.0-beta04"
 appcompat = "1.7.0"
 material = "1.12.0"
 gson-version = "2.11.0"
@@ -66,7 +66,6 @@ androidx-media3-session = { module = "androidx.media3:media3-session", version.r
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "pagingCompose" }
 androidx-paging-runtime-ktx = { module = "androidx.paging:paging-runtime-ktx", version.ref = "pagingRuntimeKtx" }
-androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "roomCompiler" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "roomKtx" }
 androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "roomPaging" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "roomRuntime" }


### PR DESCRIPTION
- chore: Update navigation-compose to 2.8.0-beta04
- Updated the version of navigation-compose dependency to 2.8
.0-beta04 in the version catalog