### PR TITLE
Working

### DIFF
--- a/.github/workflows/Build and Release.yml
+++ b/.github/workflows/Build and Release.yml
@@ -54,13 +54,13 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           retention-days: 1
           path: bitapp/build/outputs/apk/global/release/bitapp-global-release.apk
       - name: Upload Bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bundle
           retention-days: 1
@@ -126,13 +126,13 @@ jobs:
       - name: Generate Dokka docs
         run: ./gradlew dokkaHtmlMultiModule
       - name: Upload Kt docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kt-docs
           path: build/dokka
           retention-days: 1
       - name: Uploading mk-docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mk-docs
           path: mk-docs
@@ -161,7 +161,7 @@ jobs:
           cp -r htmlMultiModule/* copyDoc/generated/docs/app
           ls -la copyDoc/generated/docs/app
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: generated-docs
           path: copyDoc

--- a/.github/workflows/Pre-Release Build and Release.yml
+++ b/.github/workflows/Pre-Release Build and Release.yml
@@ -52,14 +52,14 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apk
           retention-days: 1
           path: bitapp/build/outputs/apk/beta/release/bitapp-beta-release.apk
 
       - name: Upload Bundle
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: bundle
           retention-days: 1
@@ -124,13 +124,13 @@ jobs:
       - name: Generate Dokka docs
         run: ./gradlew dokkaHtmlMultiModule
       - name: Upload Kt docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: kt-docs
           path: build/dokka
           retention-days: 1
       - name: Uploading mk-docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mk-docs
           path: mk-docs
@@ -159,7 +159,7 @@ jobs:
           cp -r htmlMultiModule/* copyDoc/generated/docs/app
           ls -la copyDoc/generated/docs/app
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: generated-docs
           path: copyDoc

--- a/.github/workflows/Pre-Release Build and Release.yml
+++ b/.github/workflows/Pre-Release Build and Release.yml
@@ -52,14 +52,14 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: apk
           retention-days: 1
           path: bitapp/build/outputs/apk/beta/release/bitapp-beta-release.apk
 
       - name: Upload Bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           retention-days: 1
@@ -124,13 +124,13 @@ jobs:
       - name: Generate Dokka docs
         run: ./gradlew dokkaHtmlMultiModule
       - name: Upload Kt docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kt-docs
           path: build/dokka
           retention-days: 1
       - name: Uploading mk-docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mk-docs
           path: mk-docs
@@ -159,7 +159,7 @@ jobs:
           cp -r htmlMultiModule/* copyDoc/generated/docs/app
           ls -la copyDoc/generated/docs/app
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: generated-docs
           path: copyDoc


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for both the build and release processes. The primary changes involve updating the version of the `upload-artifact` action used in various steps.

Updates to `.github/workflows/Build and Release.yml`:

* Updated `upload-artifact` action from v2 to v3 for uploading APK and bundle artifacts.
* Updated `upload-artifact` action from v2 to v3 for uploading Dokka docs and mk-docs.
* Updated `upload-artifact` action from v2 to v3 for uploading generated docs.

Updates to `.github/workflows/Pre-Release Build and Release.yml`:

* Updated `upload-artifact` action from v2 to v4 for uploading APK and bundle artifacts.
* Updated `upload-artifact` action from v2 to v4 for uploading Dokka docs and mk-docs.
* Updated `upload-artifact` action from v2 to v4 for uploading generated docs.